### PR TITLE
Exit successfully after rendered

### DIFF
--- a/renderStatic.js
+++ b/renderStatic.js
@@ -88,3 +88,4 @@ for(const route of routes) {
 }
 
 console.log('\nDONE\n');
+process.exit(0);


### PR DESCRIPTION
This helps the `npm run dev` script to know it can start the server after rendering the static files.