### PR TITLE
Add content hash to JS output files

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -8,8 +8,8 @@ module.exports = {
     output: {
         publicPath: '/bundles/',
         path: path.join(__dirname, '../public/bundles'),
-        filename: 'bundle.js',
-        chunkFilename: '[name].bundle.js',
+        filename: 'bundle.[contenthash].js',
+        chunkFilename: '[name].[contenthash].bundle.js',
     },
     module: {
         rules: [{


### PR DESCRIPTION
This seems to work out of the box with the current webpack configuration.

I'll send a separate PR for a more robust Webpack with Webpack 5 and HTML plugin.