### PR TITLE
Add page title to signup page

### DIFF
--- a/src/components/front/pages/SignUp.js
+++ b/src/components/front/pages/SignUp.js
@@ -155,6 +155,7 @@ export default () => {
   return (
     <Wrapper>
       <Helmet>
+        <title>{metaTitle}</title>
         <link rel="canonical" href="https://tibroish.bg/signup/" />
         <meta name="description" content={metaDescription} />
         <meta property="og:url" content={metaUrl} />


### PR DESCRIPTION
The Helmet block had `og:title` but no `<title>` tag, so the browser tab showed the default/empty title.

Adds `<title>{metaTitle}</title>` which resolves to:
- With referral: "Аз се записах за пазител на вота! Запиши се и ти!"
- Without referral: "Запиши се още сега | Ти Броиш"